### PR TITLE
Adds pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## How can a reviewer see these changes?
+
+
+
+## Reviewer Checklist
+
+- [ ] The commit message (not just PR comment) is clear and follows our
+  guidelines
+- [ ] There are tests covering any new functionality
+- [ ] The documentation has been updated if necessary
+- [ ] The changes, if applicable, have been verified
+- [ ] Any questions or concerns have been noted in the PR or on Slack,
+  discussed if appropriate, and addressed to my satisfaction


### PR DESCRIPTION
Adds a checklist for reviewers to help in focusing the code review
Unified Split

## How can a reviewer see these changes?

Once merged, new Pull requests will get a template that looks like this (this one is faked as it doesn't work until merged).

## Reviewer Checklist

- [ ] The commit message (not just PR comment) is clear and follows our
  guidelines
- [ ] There are tests covering any new functionality
- [ ] The documentation has been updated if necessary
- [ ] The changes, if applicable, have been verified
- [ ] Any questions or concerns have been noted in the PR or on Slack,
  discussed if appropriate, and addressed to my satisfaction